### PR TITLE
Fixed label width calculation in LabeledControlHost

### DIFF
--- a/src/Controls4Industry/LabeledControlHost/LabeledControlHost.cs
+++ b/src/Controls4Industry/LabeledControlHost/LabeledControlHost.cs
@@ -129,7 +129,7 @@ namespace C4I
             if (_labelHost == null || parentPanel == null || string.IsNullOrWhiteSpace(SharedSizeGroupName))
                 return;
 
-            var labeledControlHosts = parentPanel.Children.OfType<LabeledControlHost>().Where(l => l.SharedSizeGroupName == SharedSizeGroupName).ToList();
+            var labeledControlHosts = parentPanel.Children.OfType<LabeledControlHost>().Where(l => l.SharedSizeGroupName == SharedSizeGroupName && l._labelHost != null).ToList();
 
             if (labeledControlHosts.Count > 1)
             {


### PR DESCRIPTION
The fix contains that only initialized LabelControlHosts will be used for calculating the shared label width

Fixed #11 
