### PR TITLE
Update wcf view model instead of remove and replace

### DIFF
--- a/src/Moryx.Tools.WcfClient.UI.Viewer/Workspace/WcfClientInfoViewModel.cs
+++ b/src/Moryx.Tools.WcfClient.UI.Viewer/Workspace/WcfClientInfoViewModel.cs
@@ -10,37 +10,53 @@ namespace Moryx.Tools.WcfClient.UI.Viewer
 {
     internal class WcfClientInfoViewModel : PropertyChangedBase
     {
+        public WcfClientInfo Model { get; private set; }
+
         public WcfClientInfoViewModel(WcfClientInfo source)
         {
-            Source = source;
-
-            if (Version.TryParse(Source.ServerVersion, out var serverVersion))
-                MinClientVersion = $"{serverVersion.Major}.0.0";
+            UpdateModel(source);
         }
 
-        public WcfClientInfo Source { get; }
+        public void UpdateModel(WcfClientInfo clientInfo)
+        {
+            Model = clientInfo;
 
-        public string Service => Source.Service;
+            if (Version.TryParse(Model.ServerVersion, out var serverVersion))
+                MinClientVersion = $"{serverVersion.Major}.0.0";
 
-        public string Uri => Source.Uri;
 
-        public string ServerVersion => Source.ServerVersion;
+            NotifyOfPropertyChange(nameof(Service));
+            NotifyOfPropertyChange(nameof(Uri));
+            NotifyOfPropertyChange(nameof(ServerVersion));
+            NotifyOfPropertyChange(nameof(ClientVersion));
+            NotifyOfPropertyChange(nameof(MinServerVersion));
+            NotifyOfPropertyChange(nameof(MinClientVersion));
+            NotifyOfPropertyChange(nameof(State));
+            NotifyOfPropertyChange(nameof(Tries));
+            NotifyOfPropertyChange(nameof(StateBrush));
+        }
 
-        public string ClientVersion => Source.ClientVersion;
+        public string Service => Model.Service;
 
-        public string MinServerVersion => Source.MinServerVersion;
+        public string Uri => Model.Uri;
 
-        public string MinClientVersion { get; }
+        public string ServerVersion => Model.ServerVersion;
 
-        public ConnectionState State => Source.State;
+        public string ClientVersion => Model.ClientVersion;
 
-        public int Tries => Source.Tries;
+        public string MinServerVersion => Model.MinServerVersion;
+
+        public string MinClientVersion { get; private set; }
+
+        public ConnectionState State => Model.State;
+
+        public int Tries => Model.Tries;
 
         public SolidColorBrush StateBrush
         {
             get
             {
-                switch (Source.State)
+                switch (Model.State)
                 {
                     case ConnectionState.Success:
                         return Brushes.LightGreen;
@@ -59,5 +75,7 @@ namespace Moryx.Tools.WcfClient.UI.Viewer
                 }
             }
         }
+
+
     }
 }

--- a/src/Moryx.Tools.WcfClient.UI.Viewer/Workspace/WcfClientViewerWorkspaceViewModel.cs
+++ b/src/Moryx.Tools.WcfClient.UI.Viewer/Workspace/WcfClientViewerWorkspaceViewModel.cs
@@ -22,7 +22,7 @@ namespace Moryx.Tools.WcfClient.UI.Viewer
         private ObservableCollection<WcfClientInfoViewModel> _clients;
         public ObservableCollection<WcfClientInfoViewModel> Clients
         {
-            get { return _clients; }
+            get => _clients;
             set
             {
                 _clients = value;
@@ -57,27 +57,11 @@ namespace Moryx.Tools.WcfClient.UI.Viewer
         /// </summary>
         private void UpdateClientInfo(WcfClientInfo clientInfo)
         {
-            var clientVm = Clients.FirstOrDefault(c => c.Source == clientInfo);
-            var index = 0;
-
+            var clientVm = Clients.FirstOrDefault(c => c.Model == clientInfo);
             if (clientVm != null)
-            {
-                index = Clients.IndexOf(clientVm);
-            }
-
-            if (index >= 0)
-            {
-                Clients.RemoveAt(index);
-
-                if (clientInfo.State != ConnectionState.Closed)
-                {
-                    Clients.Insert(index, new WcfClientInfoViewModel(clientInfo));
-                }
-            }
+                clientVm.UpdateModel(clientInfo);
             else
-            {
                 Clients.Add(new WcfClientInfoViewModel(clientInfo));
-            }
         }
     }
 }


### PR DESCRIPTION
There was an exception if the module was started at the very first. Instead of replacing the entry by index, I update the wcf client view models.