### PR TITLE
Register IKernelConfigManager also as IConfigManager in global container

### DIFF
--- a/src/Moryx.ClientFramework.Kernel/Configuration/LocalConfigProvider.cs
+++ b/src/Moryx.ClientFramework.Kernel/Configuration/LocalConfigProvider.cs
@@ -24,7 +24,7 @@ namespace Moryx.ClientFramework.Kernel
             _configManager = configManager;
         }
 
-        /// 
+        /// <inheritdoc />
         public T GetModuleConfiguration<T>(string name) where T : class, IClientModuleConfig, new()
         {
             var config = GetConfiguration<T>();

--- a/src/Moryx.ClientFramework.Kernel/HeartOfLead.cs
+++ b/src/Moryx.ClientFramework.Kernel/HeartOfLead.cs
@@ -17,6 +17,7 @@ using System.Windows.Threading;
 using Caliburn.Micro;
 using CommandLine;
 using Moryx.ClientFramework.Localization;
+using Moryx.Configuration;
 using Moryx.Container;
 using Moryx.Logging;
 using Moryx.Threading;
@@ -359,7 +360,8 @@ namespace Moryx.ClientFramework.Kernel
 
             // Configure config manager
             _configManager = new KernelConfigManager { ConfigDirectory = CommandLineOptions.ConfigFolder };
-            _container.SetInstance(_configManager);
+            _container.SetInstance<IKernelConfigManager>(_configManager, "KernelConfigManager");
+            _container.SetInstance<IConfigManager>(_configManager, "ConfigManager");
 
             // Load global app config
             AppConfig = _configManager.GetConfiguration<AppConfig>();

--- a/src/Moryx.ClientFramework.Kernel/RunMode/LocalRunMode.cs
+++ b/src/Moryx.ClientFramework.Kernel/RunMode/LocalRunMode.cs
@@ -25,7 +25,7 @@ namespace Moryx.ClientFramework.Kernel
             get { return type => type.GetCustomAttribute<ComponentForRunModeAttribute>() == null; }
         }
 
-        /// <inheritdoc /> 
+        /// <inheritdoc />
         public override void LoadModulesConfiguration()
         {
             var modulesConfig = ConfigManager.GetConfiguration<ModulesConfiguration>();

--- a/src/Moryx.ClientFramework.Kernel/RunMode/LocalRunModeBase.cs
+++ b/src/Moryx.ClientFramework.Kernel/RunMode/LocalRunModeBase.cs
@@ -11,7 +11,7 @@ using Moryx.ClientFramework.Shell;
 namespace Moryx.ClientFramework.Kernel
 {
     /// <summary>
-    /// Base class for local run modes. 
+    /// Base class for local run modes.
     /// Will load <see cref="IClientModule"/> and <see cref="IModuleShell"/> from the app domain
     /// </summary>
     public abstract class LocalRunModeBase : RunModeBase
@@ -21,7 +21,7 @@ namespace Moryx.ClientFramework.Kernel
         /// <summary>
         /// Config manager to load kernel configurations
         /// </summary>
-        public IKernelConfigManager ConfigManager { get; set; }
+        public IKernelConfigManager ConfigManager { get; set; } // TODO: Change type to IConfigManager in future
 
         #endregion
 
@@ -75,7 +75,7 @@ namespace Moryx.ClientFramework.Kernel
         ///
         public override void LoadModulesConfiguration()
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
To request the global config manager in 3rd party components, it is required to register the IKernelConfigManager also as IConfigManager