### PR TITLE
Clearify ambigous reference in tests

### DIFF
--- a/src/Tests/Moryx.ClientFramework.Tests/AttributeTests.cs
+++ b/src/Tests/Moryx.ClientFramework.Tests/AttributeTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Moryx.Container;
 using NUnit.Framework;
+using LifeCycle = Moryx.Container.LifeCycle;
 
 namespace Moryx.ClientFramework.Tests
 {


### PR DESCRIPTION
Clearify ambigous reference in tests to fix build