### PR TITLE
Add IEditableObject interface and behavior

### DIFF
--- a/src/Moryx.Controls.Demo/ViewModels/EntryEditorViewModel.cs
+++ b/src/Moryx.Controls.Demo/ViewModels/EntryEditorViewModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Input;
@@ -13,11 +14,29 @@ namespace Moryx.Controls.Demo.ViewModels
 {
     public class EntryEditorViewModel : Screen
     {
+        private bool _isEditMode;
+
         public override string DisplayName => "EntryEditor";
 
         public EntryViewModel EntryViewModels { get; }
 
         public ICommand ShowExceptionCommand { get; }
+
+        public ICommand BeginEditCmd { get; }
+
+        public ICommand EndEditCmd { get; }
+
+        public ICommand CancelEditCmd { get; }
+
+        public bool IsEditMode
+        {
+            get { return _isEditMode; }
+            private set
+            {
+                _isEditMode = value;
+                NotifyOfPropertyChange();
+            }
+        }
 
         public EntryEditorViewModel()
         {
@@ -62,6 +81,26 @@ namespace Moryx.Controls.Demo.ViewModels
             EntryViewModels = new EntryViewModel(entry);
 
             ShowExceptionCommand = new RelayCommand(ShowException);
+            BeginEditCmd = new RelayCommand(BeginEdit);
+            EndEditCmd = new RelayCommand(EndEdit);
+            CancelEditCmd = new RelayCommand(CancelEdit);
+        }
+
+        private void EndEdit(object obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void CancelEdit(object obj)
+        {
+            IsEditMode = false;
+            EntryViewModels.CancelEdit();
+        }
+
+        private void BeginEdit(object obj)
+        {
+            IsEditMode = true;
+            EntryViewModels.BeginEdit();
         }
 
         public void ShowException(object parameter)

--- a/src/Moryx.Controls.Demo/Views/EntryEditorView.xaml
+++ b/src/Moryx.Controls.Demo/Views/EntryEditorView.xaml
@@ -11,5 +11,22 @@
              xmlns:controls="clr-namespace:Moryx.Controls;assembly=Moryx.Controls"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance viewModels:EntryEditorViewModel}">
-    <controls:EntryEditor Margin="20"  RootEntry="{Binding EntryViewModels}" IsEditMode="True" ShowExceptionCommand="{Binding ShowExceptionCommand}" />
+    <DockPanel LastChildFill="True">
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,5,5,5" HorizontalAlignment="Right">
+            <EddieButton Icon="{CommonShape Pencil}"
+                            Command="{Binding BeginEditCmd}"
+                            Content="Begin Edit"/>
+            <EddieButton Icon="{CommonShape Cross}"
+                            Margin="5,0,0,0"
+                            Command="{Binding CancelEditCmd}"
+                            Content="Cancel Edit"/>
+            <EddieButton Icon="{CommonShape CheckMark}"
+                            Margin="5,0,0,0"
+                            Command="{Binding EndEditCmd}"
+                            Content="End Edit"/>
+        </StackPanel>
+
+        <controls:EntryEditor Margin="20" DockPanel.Dock="Top" RootEntry="{Binding EntryViewModels}" IsEditMode="{Binding IsEditMode}" 
+                              ShowExceptionCommand="{Binding ShowExceptionCommand}" />
+    </DockPanel>
 </UserControl>

--- a/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
+++ b/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
@@ -1,24 +1,31 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Moryx.Serialization;
+using Moryx.Tools;
 
 namespace Moryx.Controls
 {
     /// <summary>
     /// View model that represents a page in the config editor
     /// </summary>
-    public class EntryViewModel : INotifyPropertyChanged
+    public class EntryViewModel : INotifyPropertyChanged, IEditableObject
     {
+
+        #region Fields and Properties
+        private ObservableCollection<EntryViewModel> _subEntries;
+        private string _preEditValue;
+
         /// <summary>
         /// The entry of this view model
         /// </summary>
-        public Entry Entry { get; }
+        public Entry Entry { get; private set; }
 
         /// <summary>
         /// Parent view model
@@ -26,15 +33,93 @@ namespace Moryx.Controls
         public EntryViewModel Parent { get; set; }
 
         /// <summary>
+        /// Displayed name of the <see cref="Entry"/>
+        /// </summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// Type of the value of the <see cref="Entry"/>
+        /// </summary>
+        public EntryValueType ValueType { get; private set; }
+
+        /// <summary>
+        /// Type of the unit of the value of the <see cref="Entry"/>
+        /// </summary>
+        public EntryUnitType UnitType { get; private set; }
+
+        /// <summary>
+        /// Default value of the <see cref="Entry"/>
+        /// </summary>
+        public string DefaultValue => Entry.Value.Default;
+
+        /// <summary>
+        /// Description of the <see cref="Entry"/>
+        /// </summary>
+        public string Description => Entry.Description;
+
+        /// <summary>
+        /// Flag if this entry is readonly and text boxes shall be disabled
+        /// </summary>
+        public bool IsReadOnly => Entry.Value.IsReadOnly;
+
+        // TODO: AL6 Remove direct access to Model and the helper variable _preEditValue from BeginEdit, CancelEdit and EndEdit methods
+        /// <summary>
+        /// Current value of <see cref="Entry"/>
+        /// </summary>
+        public string Value
+        {
+            get => Entry.Value.Current;
+            set
+            {
+                if (Entry.Value.Current is not null && Entry.Value.Current.Equals(value))
+                    return;
+                Entry.Value.Current = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Assignable values to the current <see cref="Entry"/>
+        /// </summary>
+        public ObservableCollection<string> PossibleValues
+        {
+            get
+            {
+                var possibleValues = Entry?.Value.Possible;
+                return possibleValues != null ? new ObservableCollection<string>(possibleValues) : null;
+            }
+        }
+
+        /// <summary>
+        /// Child instances of this <see cref="EntryViewModel"/>
+        /// </summary>
+        public ObservableCollection<EntryViewModel> SubEntries
+        {
+            get => _subEntries;
+            set
+            {
+                _subEntries = value;
+                OnPropertyChanged();
+            }
+        }
+        #endregion
+
+        #region Constructors
+        /// <summary>
         /// Initializes a new instance of the <see cref="EntryViewModel"/> class.
         /// </summary>
-        public EntryViewModel(IList<Entry> entries)
+        public EntryViewModel() : this(new Entry() { DisplayName = "Root", 
+            Value = new EntryValue() { Type = EntryValueType.Class }, SubEntries = new List<Entry>() })
         {
-            DisplayName = "Root";
-            ValueType = EntryValueType.Class;
-            SubEntries = new ObservableWrapperCollection(entries);
+        }
 
-            UpdateParent();
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntryViewModel"/> class.
+        /// </summary>
+        [Obsolete("Use Empty constructor instead")]
+        public EntryViewModel(IList<Entry> entries) : this()
+        {
+            UpdateModel(entries);
         }
 
         /// <summary>
@@ -44,56 +129,26 @@ namespace Moryx.Controls
         {
             Entry = entry;
             DisplayName = Entry.DisplayName;
+            Value = Entry.Value.Current;
             ValueType = Entry.Value.Type;
             UnitType = Entry.Value.UnitType;
-            SubEntries = new ObservableWrapperCollection(entry.SubEntries);
+            SubEntries = new ObservableCollection<EntryViewModel>(Entry.SubEntries.Select(e => new EntryViewModel(e)));
 
             UpdateParent();
         }
-
-        private void UpdateParent(EntryViewModel entry)
-        {
-            entry.Parent = this;
-        }
+        #endregion
 
         private void UpdateParent()
         {
             foreach (var entryViewModel in SubEntries)
-            {
                 UpdateParent(entryViewModel);
-            }
         }
 
-        ///
-        public string DisplayName { get; }
-
-        ///
-        public string Value
+        private void UpdateParent(EntryViewModel entry)
         {
-            get => Entry.Value.Current;
-            set
-            {
-                Entry.Value.Current = value;
-                OnPropertyChanged();
-            }
+            if (entry.Parent is null || !entry.Parent.Equals(this))
+                entry.Parent = this;
         }
-
-        ///
-        public EntryValueType ValueType { get; }
-
-        ///
-        public EntryUnitType UnitType { get; }
-
-        ///
-        public string DefaultValue => Entry.Value.Default;
-
-        ///
-        public string Description => Entry.Description;
-
-        /// <summary>
-        /// Flag if this entry is readonly and text boxes shall be disabled
-        /// </summary>
-        public bool IsReadOnly => Entry.Value.IsReadOnly;
 
         /// <summary>
         /// Add prototype of this name to the subEntries
@@ -117,68 +172,103 @@ namespace Moryx.Controls
             // Update entry
             Entry.Value = prototype.Value;
             Entry.SubEntries = prototype.SubEntries;
+            Entry.Value.Type = prototype.Value.Type;
+            Entry.Value.UnitType = prototype.Value.UnitType;
             // Update our observable collection
-            SubEntries = new ObservableWrapperCollection(Entry.SubEntries);
+            SubEntries = new ObservableCollection<EntryViewModel>(Entry.SubEntries.Select(e => new EntryViewModel(e)));
 
             UpdateParent();
         }
 
-        ///
-        public ObservableCollection<string> PossibleValues
+        /// <inheritdoc />
+        public void BeginEdit()
         {
-            get
-            {
-                var possibleValues = Entry?.Value.Possible;
-                return possibleValues != null ? new ObservableCollection<string>(possibleValues) : null;
-            }
-        }
-
-        private ObservableCollection<EntryViewModel> _subEntries;
-
-        ///
-        public ObservableCollection<EntryViewModel> SubEntries
-        {
-            get => _subEntries;
-            set
-            {
-                _subEntries = value;
-                OnPropertyChanged();
-            }
+            SubEntries.BeginEdit();
+            _preEditValue = Entry.Value.Current;
         }
 
         /// <inheritdoc />
-        public event PropertyChangedEventHandler PropertyChanged;
+        public void EndEdit()
+        {
+            SubEntries.EndEdit();
+            _preEditValue = Entry.Value.Current;
+            CopyToModel();
+        }
+
+        private void CopyToModel()
+        {
+            Entry.DisplayName = DisplayName;
+            Entry.Value.Current = Value;
+            Entry.Value.Type = ValueType;
+            Entry.Value.UnitType = UnitType;
+            Entry.SubEntries = SubEntries.Select(vm => vm.Entry).ToList(); 
+
+            UpdateParent();
+        }
+
+        /// <inheritdoc />
+        public void CancelEdit()
+        {
+            SubEntries.CancelEdit();
+            Value = _preEditValue;
+            CopyFromModel();
+        }
+
+        private void CopyFromModel()
+        {
+            DisplayName = Entry.DisplayName;
+            UnitType = Entry.Value.UnitType;
+            ValueType = Entry.Value.Type;
+            MergeIntoViewModelCollection(SubEntries, Entry.SubEntries);
+
+            UpdateParent();
+        }
+
+        private void MergeIntoViewModelCollection(ObservableCollection<EntryViewModel> entryViewModels, IList<Entry> updated)
+        {
+            // Remove those without identifiert or not existing in the updated collection
+            var removed = entryViewModels.Where(vm => vm.Entry.Identifier == "" || updated.All(e => e.Identifier != vm.Entry.Identifier)).ToList();
+            foreach (var obj in removed)
+                entryViewModels.Remove(obj);
+
+            foreach (var updatedEntry in updated)
+            {
+                var match = entryViewModels.FirstOrDefault(vm => vm.Entry.Identifier == updatedEntry.Identifier);
+                if (match is null) // Add new Entry 
+                    entryViewModels.Add(new EntryViewModel(updatedEntry));
+                else // Update Entry
+                    match.UpdateModel(updatedEntry);
+            }
+        }
+
+        /// <summary>
+        /// Updates the internal model
+        /// </summary>
+        /// <param name="entry">The updated entry instance</param>
+        public void UpdateModel(Entry entry)
+        {
+            Entry = entry;
+            CopyFromModel();
+        }
+
+        /// <summary>
+        /// Updates the internal model
+        /// </summary>
+        /// <param name="entries">The updated subentry instances</param>
+        public void UpdateModel(IList<Entry> entries)
+        {
+            MergeIntoViewModelCollection(SubEntries, entries);
+            CopyToModel();
+            UpdateParent();
+        }
+
 
         private void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-    }
 
-    internal class ObservableWrapperCollection : ObservableCollection<EntryViewModel>
-    {
-        private readonly IList<Entry> _entries;
-
-        public ObservableWrapperCollection(IList<Entry> entries)
-        {
-            _entries = entries;
-            // Copy current state to our collection
-            for (var i = 0; i < entries.Count; i++)
-            {
-                base.InsertItem(i, new EntryViewModel(entries[i]));
-            }
-        }
-
-        protected override void InsertItem(int index, EntryViewModel item)
-        {
-            _entries.Add(item.Entry);
-            base.InsertItem(index, item);
-        }
-
-        protected override void RemoveItem(int index)
-        {
-            _entries.Remove(this.ElementAt(index).Entry);
-            base.RemoveItem(index);
-        }
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }


### PR DESCRIPTION
Add IEditableObject Interface and update methods to the EntryViewModel to close #38.

For compatibility reasons the direct access to the value of the Entry property is maintained. Therefore, the update mechanism requires a helper variable.

Also the ObservableCollectionWrapper is removed, as it is used in the EntryViewModel exclusively and its functionality can be replaced with a single Select statement.