### PR TITLE
Reordered initialization

### DIFF
--- a/src/Moryx.ClientFramework.Kernel/HeartOfLead.cs
+++ b/src/Moryx.ClientFramework.Kernel/HeartOfLead.cs
@@ -118,14 +118,14 @@ namespace Moryx.ClientFramework.Kernel
             // Create global container and configure config manager
             CreateContainer();
 
-            //Configures the thread context
-            ConfigureThreadContext();
-
             // Register app config
             LoadConfiguration();
 
             // Activates the logging
             ActivateKernelLogging();
+
+            //Configures the thread context
+            ConfigureThreadContext();
 
             // ConfigureLocalization
             ConfigureLocalization();


### PR DESCRIPTION
Initilalizing the thread context before the logging context results in a null reference exception at runtime because the
logger is null in the error catcher.

Easiest way to reproduce is to use ThreadContext.Dispatcher.BeginInvoke and throw an exception in the delegate after the initialisation.

