### PR TITLE
Ensured that OnPropertyChanged is invoked on UIThread.

### DIFF
--- a/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
+++ b/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
@@ -80,7 +80,6 @@ namespace Moryx.Controls
                 Dispatcher.CurrentDispatcher.Invoke(() =>
                 {
                     OnPropertyChanged();
-                    // Assuming you're inside an EntryViewModel instance
                 });
             }
         }
@@ -113,7 +112,6 @@ namespace Moryx.Controls
                 Dispatcher.CurrentDispatcher.Invoke(() =>
                 {
                     OnPropertyChanged();
-                    // Assuming you're inside an EntryViewModel instance
                 });
             }
         }

--- a/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
+++ b/src/Moryx.Controls/EntryEditor/EntryViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows.Threading;
 using Moryx.Serialization;
 using Moryx.Tools;
 
@@ -76,7 +77,11 @@ namespace Moryx.Controls
                 if (Entry.Value.Current is not null && Entry.Value.Current.Equals(value))
                     return;
                 Entry.Value.Current = value;
-                OnPropertyChanged();
+                Dispatcher.CurrentDispatcher.Invoke(() =>
+                {
+                    OnPropertyChanged();
+                    // Assuming you're inside an EntryViewModel instance
+                });
             }
         }
 
@@ -105,7 +110,11 @@ namespace Moryx.Controls
                     _subEntries.CollectionChanged -= SyncSubEntries;
                 _subEntries = value;
                 _subEntries.CollectionChanged += SyncSubEntries;
-                OnPropertyChanged();
+                Dispatcher.CurrentDispatcher.Invoke(() =>
+                {
+                    OnPropertyChanged();
+                    // Assuming you're inside an EntryViewModel instance
+                });
             }
         }
 

--- a/src/Moryx.WpfToolkit/Base/EddieButtonBase/EddieButtonBase.cs
+++ b/src/Moryx.WpfToolkit/Base/EddieButtonBase/EddieButtonBase.cs
@@ -8,7 +8,7 @@ using System.Windows.Media;
 namespace Moryx.WpfToolkit
 {
     /// <summary>
-    /// Bass class for the eddie buttons which adds some dependency properties to the
+    /// Base class for the eddie buttons which adds some dependency properties to the
     /// basic <see cref="Button"/>
     /// </summary>
     public abstract class EddieButtonBase : Button


### PR DESCRIPTION
Because the values of the EntryViewModel are updated from an async task, while using an importer, it is important to make sure, that the OnPropertyChanged is Invoked from the UI thread. Otherwise the updated information is not updated in the View.

The problem occurred while implementing an importer. Compare: https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer/blob/db3eeb42343e8c8c6eea5c55232bb1a334df784a/docs/articles/Products/ProductImport.md?plain=1#L13